### PR TITLE
Fix issue #30

### DIFF
--- a/scripts.d/220_checknvmebus.sh
+++ b/scripts.d/220_checknvmebus.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+DESCRIPTION="Check for any NVMe devices on PCIe bus addresses >= 0x10000"
+SCRIPT_TYPE="parallel"
+
+nvme_buses=$(lspci | awk -F ':' '/Non-Volatile memory controller/ { print "0x"$1 }')
+
+non_compliant_bus_ids=()
+
+for bus_id in $nvme_buses; do
+	if [[ $bus_id -ge 0x10000 ]]; then
+		non_compliant_bus_ids+=("$bus_id")
+	fi
+done
+
+if [ "${#non_compliant_bus_ids[@]}" -eq 0 ]; then
+	write_log 'There are no NVMe devices on bus IDs at or above 10000.'
+	exit 0
+else
+	write_log "Non-compliant PCIe bus addresses: ${non_compliant_bus_ids[*]}"
+	write_log 'See `lspci` for further details. These are incompatible with DPDK.'
+	write_log 'You may need to disable Intel VMD or exclude these devices from'
+	write_log 'VMD in the BIOS, or exclude these devices from your WEKA cluster.'
+	exit 254
+fi


### PR DESCRIPTION
Add check for NVMe devices attached to buses above or equal to 0x10000.

Note that testing this is almost impossible without a problematic system; I had to instead replace the `lspci` call with `printf '00:03.0 Non-Volatile memory controller: Red Hat, Inc. QEMU NVM Express Controller (rev 02)\n10000:02:00 Non-Volatile memory controller\nfffffe:02:00 Non-Volatile memory controller'`. Tried attaching a virtualised NVMe device with this address but it simply stuck to its "normal" (lowest possible) address.