### PR TITLE
Make OS information variables available in environment

### DIFF
--- a/scripts.d/010_ping.sh
+++ b/scripts.d/010_ping.sh
@@ -9,18 +9,18 @@ ret="1"
 
 which ping &> /dev/null
 if [ $? -eq 1 ]; then
-	if [ "$DIST" == "ubuntu" ]; then
+	if [[ $ID_LIKE == *debian* ]]; then
 		PACKAGE="iputils-ping"
-	else
+	elif [[ $ID_LIKE == *rhel* ]]; then
 		PACKAGE="iputils"
 	fi
 	echo "ping not found." 
 	if [ "$FIX" == "True" ]; then
 		echo "Fix requested. Installing ping"
-		if [ "$DIST" == "ubuntu" ]; then
+		if [[ $ID_LIKE == *debian* ]]; then
 			sudo apt-get update
 			sudo apt-get -y install iputils-ping
-		else
+		elif [[ $ID_LIKE == *rhel* ]]; then
 			sudo yum -y install iputils
 		fi
 	else

--- a/scripts.d/060_clockdiff.sh
+++ b/scripts.d/060_clockdiff.sh
@@ -9,18 +9,18 @@ ret="0"
 # Put your stuff here
 which clockdiff &> /dev/null
 if [ $? -eq 1 ]; then
-	if [ "$DIST" == "ubuntu" ]; then
+	if [[ $ID_LIKE == *debian* ]]; then
 		PACKAGE="iputils-clockdiff"
-	else
+	elif [[ $ID_LIKE == *rhel* ]]; then
 		PACKAGE="iputils"
 	fi
 	echo "clockdiff not found." 
 	if [ "$FIX" == "True" ]; then
 		echo "Fix requested. Installing clockdiff"
-		if [ "$DIST" == "ubuntu" ]; then
+		if [[ $ID_LIKE == *debian* ]]; then
 			sudo apt-get update
 			sudo apt-get -y install iputils-clockdiff
-		else
+		elif [[ $ID_LIKE == *rhel* ]]; then
 			sudo yum -y install iputils
 		fi
 		which clockdiff &> /dev/null

--- a/scripts.d/110_checkos.sh
+++ b/scripts.d/110_checkos.sh
@@ -6,27 +6,6 @@ SCRIPT_TYPE="parallel"
 # Currently supported releases:
 ## https://docs.weka.io/support/prerequisites-and-compatibility
 
-source /etc/os-release
-
-# CentOS doesn't include subversion (e.g. 7.x) information in /etc/os-release,
-# so we set it from /etc/redhat-release
-# Format: CentOS Linux release 7.9.2009 (Core)
-if [ "$ID" = 'centos' ]; then
-	VERSION_ID=$(cat /etc/redhat-release)
-
-	# Remove everything before the number, leaving "7.9.2009 (Core)"
-	VERSION_ID=${VERSION_ID##*release }
-
-	# Remove everything from the date to the end, leaving "7.9"
-	VERSION_ID=${VERSION_ID%.*}
-
-# Ubuntu doesn't include subversion (e.g. 20.04.x) information in VERSION_ID in
-# /etc/os-release, so we set it from VERSION in /etc/os-release
-elif [ "$ID" = 'ubuntu' ]; then
-	# Remove everything after the number, leaving "20.04.3"
-	VERSION_ID=${VERSION%% *}
-fi
-
 distro_not_found=0
 version_not_found=0
 unsupported_distro=0

--- a/scripts.d/145_checkwekapackages.sh
+++ b/scripts.d/145_checkwekapackages.sh
@@ -8,7 +8,7 @@ install_needed=""
 
 missing_list=()
 
-if [ "$DIST" == "redhat" ]; then
+if [[ $ID_LIKE == *rhel* ]]; then
 	write_log "REQUIRED packages missing for weka installation (Red Hat based system)"
 	red_hat_pkg_list_weka=( "elfutils-libelf-devel" \
                              "gcc" "glibc-headers" "glibc-devel" \
@@ -36,7 +36,7 @@ if [ "$DIST" == "redhat" ]; then
         fi
     fi
 
-else
+elif [[ $ID_LIKE == *debian* ]]; then
 	write_log "REQUIRED packages missing for weka installation (Debian/Ubuntu based system)"
 	debian_pkg_list_weka=( "libelf-dev" "linux-headers-$(uname -r)" \
                             "gcc" "make" "perl" "python2-minimal" \

--- a/scripts.d/146_checkofedpackages.sh
+++ b/scripts.d/146_checkofedpackages.sh
@@ -9,7 +9,7 @@ remove_needed=""
 
 missing_list=()
 
-if [ "$DIST" == "redhat" ]; then
+if [[ $ID_LIKE == *rhel* ]]; then
 	write_log "REQUIRED packages missing for OFED installation (Red Hat based system)"
 
 	red_hat_pkg_list_ofed=( "pciutils" "cairo" "gcc-gfortran" 
@@ -38,7 +38,7 @@ if [ "$DIST" == "redhat" ]; then
         fi
     fi
 
-else
+elif [[ $ID_LIKE == *debian* ]]; then
 	write_log "REQUIRED packages missing for OFED installation (Debian/Ubuntu based system)"
 	debian_pkg_list_ofed=( "pciutils" "cairo" "python-libxml2" \
                             "tcsh" "lsof" "tcl" "tk" "zlib1g-dev" "curl" )

--- a/scripts.d/147_checkoptpackages.sh
+++ b/scripts.d/147_checkoptpackages.sh
@@ -9,7 +9,7 @@ remove_needed=""
 
 missing_list=()
 
-if [ "$DIST" == "redhat" ]; then
+if [[ $ID_LIKE == *rhel* ]]; then
 	write_log "RECOMMENDED packages missing for WEKA runtime (RedHat based system):"
 
 	red_hat_pkg_list_general=( "epel-release" "sysstat" "strace" "ipmitool" "tcpdump" "telnet" "nmap" "net-tools" \
@@ -39,7 +39,7 @@ if [ "$DIST" == "redhat" ]; then
         fi
     fi
 
-else
+elif [[ $ID_LIKE == *debian* ]]; then
 	write_log "RECOMMENDED packages missing for WEKA runtime (Debian/Ubuntu based system):"
 
 	debian_pkg_list_general=( "net-tools" "wget" "sg3-utils" "gdisk" "ntpdate" "ipmitool" "sysstat" "strace" \

--- a/scripts.d/preamble
+++ b/scripts.d/preamble
@@ -35,12 +35,31 @@ while (( "$#" )); do
       ;;
   esac
 done
-which dpkg &> /dev/null
-if [ $? -eq 1 ]; then
-        DIST="redhat"
-else
-	DIST="ubuntu"
+
+# Set OS information in environment
+source /etc/os-release
+
+# CentOS doesn't include subversion (e.g. 7.x) information in /etc/os-release,
+# so we set it from /etc/redhat-release
+# Format: CentOS Linux release 7.9.2009 (Core)
+if [ "$ID" = 'centos' ]; then
+	VERSION_ID=$(cat /etc/redhat-release)
+
+	# Remove everything before the number, leaving "7.9.2009 (Core)"
+	VERSION_ID=${VERSION_ID##*release }
+
+	# Remove everything from the date to the end, leaving "7.9"
+	VERSION_ID=${VERSION_ID%.*}
+
+# Ubuntu doesn't include subversion (e.g. 20.04.x) information in VERSION_ID in
+# /etc/os-release, so we set it from VERSION in /etc/os-release
+elif [ "$ID" = 'ubuntu' ]; then
+	# Remove everything after the number, leaving "20.04.3"
+	VERSION_ID=${VERSION%% *}
 fi
+
 # set positional arguments in their proper place
 eval set -- "$PARAMS"
 PATH=$PATH:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin
+
+# vim: set filetype=bash:


### PR DESCRIPTION
Sources and modifies /etc/os-release variables so that they are available as environment variables in all scripts. See scripts.d/preamble to see how this is parsed (and thus valid values).