### PR TITLE
Replace calls to jq with calls to python3 + json module

### DIFF
--- a/scripts.d/ta/260_compare_dpdk_gateways.sh
+++ b/scripts.d/ta/260_compare_dpdk_gateways.sh
@@ -14,6 +14,6 @@ for WEKA_CONTAINER in $(sudo weka local ps --output name --no-header); do
           ( ${WEKA_CONTAINER} == "smb"   ) ]] ; then
         continue
     fi
-    sudo weka local resources --container ${WEKA_CONTAINER} --json | jq -r "[.net_devices[].gateway] | .[]" | sort -n
+    sudo weka local resources --container ${WEKA_CONTAINER} --json | python3 -c 'import sys, json; data = json.load(sys.stdin); print("\n".join([device["gateway"] for device in data["net_devices"]]))' | sort -n
 done
 ) | sha256sum | awk '{print $1}'

--- a/scripts.d/ta/270_weka_local_resources_gateways.sh
+++ b/scripts.d/ta/270_weka_local_resources_gateways.sh
@@ -15,9 +15,11 @@ for WEKA_CONTAINER in $(sudo weka local ps --output name --no-header); do
         continue
     fi
     # Look for network devices with no gateway
-    NUMBER_OF_DEVICES_WITH_NO_GATEWAY=$(sudo weka local resources --container ${WEKA_CONTAINER} --json | jq -cr '[.net_devices[]|select(.gateway=="")|.name] | length' )
+    NUMBER_OF_DEVICES_WITH_NO_GATEWAY=$(sudo weka local resources --container ${WEKA_CONTAINER} --json | python3 -c 'import sys, json; data = json.load(sys.stdin); print(len([device for device in data["net_devices"] if device["gateway"] == ""]))')
+
+
     if [[ ${NUMBER_OF_DEVICES_WITH_NO_GATEWAY} -ne 0 ]] ; then
-        DEVICES_WITH_NO_GATEWAY=$(sudo weka local resources --container ${WEKA_CONTAINER} --json | jq -cr '[ .net_devices[]|select(.gateway=="")|.name ]')
+        DEVICES_WITH_NO_GATEWAY=$(sudo weka local resources --container ${WEKA_CONTAINER} --json | python3 -c 'import sys, json; data = json.load(sys.stdin); print("\n".join([device["name"] for device in data["net_devices"] if device["gateway"] == ""]))')
         echo "The container ${WEKA_CONTAINER} has the following network devices defined without an IP"
         echo "gateway - this might not be a mistake but means Weka POSIX traffic will not"
         echo "leave this subnet"

--- a/scripts.d/ta/290_check_traces_free_space.sh
+++ b/scripts.d/ta/290_check_traces_free_space.sh
@@ -10,7 +10,7 @@ RETURN_CODE=0
 
 WEKA_TRACES_DIR="/opt/weka/traces"
 
-WEKA_ENSURE_FREE=$(weka debug traces status --json | jq .servers_ensure_free.value)   # bytes
+WEKA_ENSURE_FREE=$(weka debug traces status --json | python3 -c 'import sys, json; data = json.load(sys.stdin); print(data["servers_ensure_free"]["value"])')   # bytes
 TRACES_FS_SIZE_KB=$(df -BK ${WEKA_TRACES_DIR} --output=size | tail -n -1 | sed s/K$//) # kibibytes
 TRACES_FS_SIZE=$((${TRACES_FS_SIZE_KB}*1024)) # kibibytes
 

--- a/scripts.d/ta/330_nfs_v4_ip_address_failover.sh
+++ b/scripts.d/ta/330_nfs_v4_ip_address_failover.sh
@@ -11,8 +11,8 @@ KB_REFERENCE="KB 1184"
 
 RETURN_CODE=0
 
-WEKA_NFS_V4_SUPPORT_IN_USE=$(weka nfs permission --json  | jq ".[].supported_versions" | grep V4 | wc -l)
-WEKA_NFS_INTERFACE_GROUP_WITH_FLOATING_IPS_COUNT=$(weka nfs interface-group --json | jq '.[].ips | length' | grep -v "^0$" | wc -l)
+WEKA_NFS_V4_SUPPORT_IN_USE=$(weka nfs permission --json  | python3 -c 'import sys, json; data = json.load(sys.stdin); print(len([permission for permission in data if "V4" in permission.get("supported_versions", [])]))')
+WEKA_NFS_INTERFACE_GROUP_WITH_FLOATING_IPS_COUNT=$(weka nfs interface-group --json | python3 -c 'import sys, json; data = json.load(sys.stdin); print(sum([len(ig["ips"]) for ig in data]))')
 
 if [[ ( ${WEKA_NFS_V4_SUPPORT_IN_USE} -ne "0" ) && \
       ( ${WEKA_NFS_INTERFACE_GROUP_WITH_FLOATING_IPS_COUNT} -ne "0" ) ]] ; then

--- a/scripts.d/ta/400_s3_using_etcd.sh
+++ b/scripts.d/ta/400_s3_using_etcd.sh
@@ -25,7 +25,7 @@ WEKA_S3_RUNNING=$(weka s3 cluster --json | grep active | grep true | wc -l)
 
 if [ ${WEKA_S3_RUNNING} -ge 1 ] ; then 
     if verlte ${MIN_VERSION} ${WEKA_VERSION} && verlte ${WEKA_VERSION} ${MAX_VERSION} ; then
-        WEKA_ETCD_HOSTS=$(weka s3 cluster --json | jq ".etcd_cluster_hosts|length")
+        WEKA_ETCD_HOSTS=$(weka s3 cluster --json | python3 -c 'import sys, json; data = json.load(sys.stdin); print(len(data["etcd_cluster_hosts"]))'
         if [ ${WEKA_ETCD_HOSTS} -gt 0 ] ; then
             echo "S3 cluster is running, and this version of Weka requires migration"
             if [[ ! -z "${WTA_REFERENCE}" ]]; then

--- a/scripts.d/ta/460_ip_source-based_routing.sh
+++ b/scripts.d/ta/460_ip_source-based_routing.sh
@@ -19,41 +19,42 @@ NUMBER_OF_ARP_FILTER_VERIFIED="0"
 while read -r ROUTING_COUNT ROUTING_DESTINATION ; do
     # If we have more than one route somewhere
     if [[ ${ROUTING_COUNT} -gt "1" ]]; then
-        # Now check how many devices route to that destination - more than 1 indicates we probably need to be using SBR
-        NUMBER_OF_DEVICES=$(ip -4 --json route | jq -cr '[.[]|select(.dst=="'${ROUTING_DESTINATION}'")]|length')
-        if [[ ${NUMBER_OF_DEVICES} -gt "1" ]] ; then
-            SOURCE_BASED_ROUTING_RECOMMENDED="1"
+        SOURCE_BASED_ROUTING_RECOMMENDED="1"
 
-            # For each preferred source (i.e. source IP), check that an IP routing rule (directing us to a routing table) exists
-            while read -r MAIN_TABLE_ROUTING_DESTINATION MAIN_TABLE_ROUTING_DEVICE MAIN_TABLE_ROUTING_PROTOCOL MAIN_TABLE_ROUTING_SCOPE MAIN_TABLE_ROUTING_SOURCE ; do
+        # For each preferred source (i.e. source IP), check that an IP routing rule (directing us to a routing table) exists
+        while read -r MAIN_TABLE_ROUTING_DESTINATION MAIN_TABLE_ROUTING_DEVICE MAIN_TABLE_ROUTING_PROTOCOL MAIN_TABLE_ROUTING_SCOPE MAIN_TABLE_ROUTING_SOURCE ; do
 
-                VALID_MATCHING_ROUTE_DESTINATION_IN_TABLE=0
-                VALID_MATCHING_ROUTE_DEVICE_IN_TABLE=0
+            VALID_MATCHING_ROUTE_DESTINATION_IN_TABLE=0
+            VALID_MATCHING_ROUTE_DEVICE_IN_TABLE=0
 
-                # For each (hopefully) device-specific routing table, check that they contain routes to the original destination with the correct device, otherwise they won't get used.
-                for ROUTING_TABLE in $(ip -4 --json rule | jq -cr '.[]|select(.src=="'${MAIN_TABLE_ROUTING_SOURCE}'")|.table') ; do
-                    let NUMBER_OF_ROUTING_TABLES_SEEN="${NUMBER_OF_ROUTING_TABLES_SEEN}+1"
+            # For each (hopefully) device-specific routing table, check that they contain routes to the original destination with the correct device, otherwise they won't get used.
+            for ROUTING_TABLE in $(ip -4 --json rule | python3 -c 'import sys, json, collections; data = json.load(sys.stdin) ; print(" ".join([r["table"] for r in data if "'${MAIN_TABLE_ROUTING_SOURCE}'" in r.get("src")]))') ; do
+                let NUMBER_OF_ROUTING_TABLES_SEEN="${NUMBER_OF_ROUTING_TABLES_SEEN}+1"
 
-                    while read -r INDIVIDUAL_ROUTE_DESTINATION INDIVIDUAL_ROUTE_DEVICE ; do
-                        if [ "${INDIVIDUAL_ROUTE_DESTINATION}" = "${MAIN_TABLE_ROUTING_DESTINATION}" ]  && [ "${INDIVIDUAL_ROUTE_DEVICE}" = "${MAIN_TABLE_ROUTING_DEVICE}" ] ; then
-                            let NUMBER_OF_ROUTING_TABLES_VERIFIED="${NUMBER_OF_ROUTING_TABLES_VERIFIED}+1"
+                while read -r INDIVIDUAL_ROUTE_DESTINATION INDIVIDUAL_ROUTE_DEVICE ; do
+                    if [ "${INDIVIDUAL_ROUTE_DESTINATION}" = "${MAIN_TABLE_ROUTING_DESTINATION}" ]  && [ "${INDIVIDUAL_ROUTE_DEVICE}" = "${MAIN_TABLE_ROUTING_DEVICE}" ] ; then
+                        let NUMBER_OF_ROUTING_TABLES_VERIFIED="${NUMBER_OF_ROUTING_TABLES_VERIFIED}+1"
 
-                            #Check that arp_announce=2 and arp_filter=1 for this interface, as per docs
-                            ARP_ANNOUNCE=$(sysctl -n net.ipv4.conf.${INDIVIDUAL_ROUTE_DEVICE}.arp_announce)
-                            ARP_FILTER=$(  sysctl -n net.ipv4.conf.${INDIVIDUAL_ROUTE_DEVICE}.arp_filter)
-                            if [[ ${ARP_ANNOUNCE} -eq "2" ]] ; then
-                                let NUMBER_OF_ARP_ANNOUNCE_VERIFIED="${NUMBER_OF_ARP_ANNOUNCE_VERIFIED}+1"
-                            fi
-                            if [[ ${ARP_FILTER} -eq "1" ]] ; then
-                                let NUMBER_OF_ARP_FILTER_VERIFIED="${NUMBER_OF_ARP_FILTER_VERIFIED}+1"
-                            fi
+                        #Check that arp_announce=2 and arp_filter=1 for this interface, as per docs
+                        ARP_ANNOUNCE=$(sysctl -n net.ipv4.conf.${INDIVIDUAL_ROUTE_DEVICE}.arp_announce)
+                        ARP_FILTER=$(  sysctl -n net.ipv4.conf.${INDIVIDUAL_ROUTE_DEVICE}.arp_filter)
+                        if [[ ${ARP_ANNOUNCE} -eq "2" ]] ; then
+                            let NUMBER_OF_ARP_ANNOUNCE_VERIFIED="${NUMBER_OF_ARP_ANNOUNCE_VERIFIED}+1"
                         fi
-                    done < <(ip -4 --json route list table ${ROUTING_TABLE} | jq -cr ".[]|[(.dst, .dev)] | @tsv")
-                done
-            done < <(ip -4 --json route | jq -cr '.[]|select(.dst=="'${ROUTING_DESTINATION}'") | [.dst, .dev, .protocol, .scope, .prefsrc] | @tsv') 
-        fi
+                        if [[ ${ARP_FILTER} -eq "1" ]] ; then
+                            let NUMBER_OF_ARP_FILTER_VERIFIED="${NUMBER_OF_ARP_FILTER_VERIFIED}+1"
+                        fi
+                    fi
+                done < <(ip -4 --json route list table ${ROUTING_TABLE} | python3 -c 'import sys, json, collections; data = json.load(sys.stdin) ; print("\n".join([(r["dst"] + " " + r["dev"]) for r in data]))')
+            done
+        done < <(ip -4 --json route  | python3 -c 'import sys, json; data = json.load(sys.stdin)
+for r in data:
+    if "'${ROUTING_DESTINATION}'" != r["dst"]:
+        continue                                                                                                        
+    print(r["dst"], r["dev"], r["protocol"], r["scope"], r["prefsrc"])
+')
     fi
-done < <(ip -4 --json route | jq -cr '.[]|select(.dst!="default")|.dst' | sort | uniq -c) # get all the unique destinations out of the routing table
+done < <(ip -4 --json route | python3 -c 'import sys, json, collections; data = json.load(sys.stdin) ; from collections import Counter ; unique_routes=Counter([route["dst"] for route in data if "default" not in route.get("dst")]) ; print("\n".join([(str(unique_routes['route']) + " " + route) for route in unique_routes.keys()]))') # get (and count) all the unique non-default destinations out of the routing table
 
 
 if [[ ${SOURCE_BASED_ROUTING_RECOMMENDED} -ge "1" ]] ; then

--- a/scripts.d/ta/490_ip_route_metrics.sh
+++ b/scripts.d/ta/490_ip_route_metrics.sh
@@ -9,7 +9,7 @@ WTA_REFERENCE=""
 KB_REFERENCE="SFDC 12492"
 RETURN_CODE=0
 
-NUMBER_OF_ROUTES_WITH_METRICS=$(ip --json route | jq "[.[]|select(.metric!=null)]|length")
+NUMBER_OF_ROUTES_WITH_METRICS=$(ip -4 --json route | python3 -c 'import sys, json; data = json.load(sys.stdin) ; print(len([r for r in data if r.get("metric") and r["metric"]]))')
 
 if [[ ${NUMBER_OF_ROUTES_WITH_METRICS} -gt "0" ]]; then
     RETURN_CODE="254"

--- a/scripts.d/ta/500_sysctl_rp_filter.sh
+++ b/scripts.d/ta/500_sysctl_rp_filter.sh
@@ -9,7 +9,7 @@ WTA_REFERENCE=""
 KB_REFERENCE="SFDC 12492"
 RETURN_CODE=0
 
-for INTERFACE_NAME in $(ip --json addr | jq -cr '.[]|select(.link_type!="loopback")|.ifname') ; do
+for INTERFACE_NAME in $(ip --json addr | python3 -c 'import sys, json; data = json.load(sys.stdin) ; print(" ".join([a["ifname"] for a in data if "loopback" not in a.get("link_type")]));') ; do
     RP_FILTER_VALUE=$(sysctl -n net.ipv4.conf.${INTERFACE_NAME}.rp_filter)
     if [[ "${RP_FILTER_VALUE}" != "0" && "${RP_FILTER_VALUE}" != "2" ]]; then
         RETURN_CODE="254"

--- a/scripts.d/ta/510_check_for_noprefixroute.sh
+++ b/scripts.d/ta/510_check_for_noprefixroute.sh
@@ -9,7 +9,8 @@ WTA_REFERENCE=""
 KB_REFERENCE="SFDC 12492"
 RETURN_CODE=0
 
-NOPREFIXROUTE_COUNT=$(ip --json addr | jq '[.[].addr_info[]|select((.family=="inet")and(.noprefixroute))]|length')
+# look for addr_info["family"] == "inet" && addr_info["noprefixroute"]
+NOPREFIXROUTE_COUNT=$(ip --json addr | python3 -c 'import sys, json; data = json.load(sys.stdin) ; print(len([addr for entry in data for addr in entry["addr_info"] if addr.get("family") == "inet" and addr.get("noprefixroute")]))')
 
 if [[ "${NOPREFIXROUTE_COUNT}" != "0" ]]; then
     RETURN_CODE="254"

--- a/scripts.d/ta/520_bucket_and_process_uptime.sh
+++ b/scripts.d/ta/520_bucket_and_process_uptime.sh
@@ -9,8 +9,8 @@ WTA_REFERENCE=""
 KB_REFERENCE=""
 RETURN_CODE=0
 
-MOST_RECENT_BUCKET_STARTTIME=$( date +%s --date=$(weka cluster bucket  --json -s uptime | jq -cr '.|last|.up_since'))
-MOST_RECENT_PROCESS_STARTTIME=$(date +%s --date=$(weka cluster process --json -s uptime | jq -cr '.|last|.up_since'))
+MOST_RECENT_BUCKET_STARTTIME=$( date +%s --date=$(weka cluster bucket  --json -s -uptime | python3 -c 'import sys, json; data = json.load(sys.stdin) ; print(data[0]["up_since"])'))
+MOST_RECENT_PROCESS_STARTTIME=$(date +%s --date=$(weka cluster process --json -s -uptime | python3 -c 'import sys, json; data = json.load(sys.stdin) ; print(data[0]["up_since"])'))
 CURRENT_TIME=$(                 date +%s)
 
 if [[ $((${CURRENT_TIME}-${MOST_RECENT_BUCKET_STARTTIME})) -lt 3600 ]]; then


### PR DESCRIPTION
At the moment we can only call shell scripts in wekachecker. This means that the natural solution to parse JSON is jq, but we can't rely on jq being available on default installations of older distributions (such as RHEL7).

As Python3 is more likely to be more widely installed (and these changes only require the sys, json, and collection modules, which are expected to be stable) it seems the only acceptable change is to remove the dependency on jq and move to Python3.

This has led to some less-readable code (in particular in the script 460_ip_source-based_routing.sh) so improvements are welcome.