### PR TITLE
Cst jack single dns entry

### DIFF
--- a/scripts.d/ta/010_ping.sh
+++ b/scripts.d/ta/010_ping.sh
@@ -45,14 +45,14 @@ if [ $# -gt 0 ]; then
 	for i in $*
 	do
 	  # resolve the name, in case we have a name, not an ip addr
-	  QUICKPING=`ping -c1 $i`
+	  QUICKPING=`ping -4 -c1 $i`
 	  if [ $? -gt 0 ]; then
 	      PINGERRORS=$PINGERRORS+1
 		  echo "   *FAIL: Unable to ping $i"
 		  echo "        $QUICKPING"
 		  exit "255"
 	  fi
-      IPRESOLVED=`ping -c1 $i | head -1 | cut '-d ' -f3`
+      IPRESOLVED=`ping -4 -c1 $i | head -1 | cut '-d ' -f3`
       DESTIPADDR=${IPRESOLVED:1:-1}
 	  # using sed below because the output of the 'ip' command isn't strictly columnar; data may be in different columns
 	  # determine which interface will be used to get to this address
@@ -102,7 +102,7 @@ if [ $# -gt 0 ]; then
 			continue
       fi
 	  # check for jumbo frames working correctly as well as basic connectivity.
-	  sudo ping -M 'do' -c 2 -i 0.2 -s $PINGMTU  $i &> /dev/null
+	  sudo ping -4 -M 'do' -c 2 -i 0.2 -s $PINGMTU  $i &> /dev/null
 	  if [ ! $? -eq 0 ]; then	# change to not eq 0
 		echo $PINGOUT
 		echo "   *FAIL: Host $i JUMBO FRAME packet test error over $IF."
@@ -136,5 +136,4 @@ fi
 if [ $ROUTEWARNS -gt 0 ]; then
 	exit "254"		
 fi
-echo "All tests passed."
 exit "0"

--- a/scripts.d/ta/125_checkinternet.sh
+++ b/scripts.d/ta/125_checkinternet.sh
@@ -4,9 +4,9 @@ DESCRIPTION="Check if internet connection available..."
 SCRIPT_TYPE="parallel"
 
 # Checking if there is an internet connection available
-ping -c2 -i1 -W 1 aws.amazon.com | grep -i "bytes from" &> /dev/null
+ping -4 -c2 -i1 -W 1 aws.amazon.com | grep -i "bytes from" &> /dev/null
 if [ $? -eq 1 ]; then
-	ping -c2 -i1 -W 1 -W 2 13.33.27.206 | grep -i "bytes from" &> /dev/null
+	ping -4 -c2 -i1 -W 1 -W 2 13.33.27.206 | grep -i "bytes from" &> /dev/null
 	if [ $? -eq 1 ]; then
 		echo "Internet connection unavailable"
 		ret="254"

--- a/scripts.d/ta/490_ip_route_metrics.sh
+++ b/scripts.d/ta/490_ip_route_metrics.sh
@@ -10,10 +10,10 @@ KB_REFERENCE="SFDC 12492"
 RETURN_CODE=0
 
 # check if the ip command supports --json
-ip --json &> /dev/null
+ip --json addr &> /dev/null
 status=$?
 if [[ $status -ne 0 ]]; then
-    echo "ERROR: Not able to run ip --json command"
+    echo "ERROR: Not able to run ip --json addr command"
     if [[ $status -eq 127 ]]; then
         echo "ip command not found"
     fi

--- a/scripts.d/ta/510_check_for_noprefixroute.sh
+++ b/scripts.d/ta/510_check_for_noprefixroute.sh
@@ -10,10 +10,10 @@ KB_REFERENCE="SFDC 12492"
 RETURN_CODE=0
 
 # check if the ip command supports --json
-ip --json &> /dev/null
+ip --json addr &> /dev/null
 status=$?
 if [[ $status -ne 0 ]]; then
-    echo "ERROR: Not able to run ip --json command"
+    echo "ERROR: Not able to run ip --json addr command"
     if [[ $status -eq 127 ]]; then
         echo "ip command not found"
     fi

--- a/scripts.d/ta/540_check_for_obs_in_scarce_mode.sh
+++ b/scripts.d/ta/540_check_for_obs_in_scarce_mode.sh
@@ -31,4 +31,8 @@ for OBS_ID in $(weka fs tier s3 --json | python3 -c 'import sys, json; data = js
     fi
 done
 
+if [[ ${RETURN_CODE} -eq 0 ]]; then
+    echo "No Object Stores found in scarce mode"
+fi
+
 exit ${RETURN_CODE}

--- a/scripts.d/ta/550_iptables_nats_local_traffic.sh
+++ b/scripts.d/ta/550_iptables_nats_local_traffic.sh
@@ -33,4 +33,8 @@ for IP_ROUTE in $(ip -4 --json route list  | python3 -c 'import sys, json, colle
     fi
 done
 
+if [[ ${RETURN_CODE} -eq 0 ]]; then
+    echo "No iptables re-writing local addresses witnessed"
+fi
+
 exit ${RETURN_CODE}

--- a/scripts.d/ta/560_check_for_swap.sh
+++ b/scripts.d/ta/560_check_for_swap.sh
@@ -17,4 +17,8 @@ if [[ ${SWAPTOTAL} -ne "0" ]] ; then
     RETURN_CODE="254"
 fi
 
+if [[ ${RETURN_CODE} -eq 0 ]]; then
+    echo "No swap found - this is a good thing"
+fi
+
 exit ${RETURN_CODE}

--- a/scripts.d/ta/570_does_weka_use_swap.sh
+++ b/scripts.d/ta/570_does_weka_use_swap.sh
@@ -21,4 +21,8 @@ for WEKAPID in $(ps -eo pid,comm | grep weka_init | awk '{print $1}') ; do
     fi
 done
 
+if [[ ${RETURN_CODE} -eq 0 ]]; then
+    echo "No Weka processes found using swap"
+fi
+
 exit ${RETURN_CODE}

--- a/scripts.d/ta/580_weka_version_available_everywhere.sh
+++ b/scripts.d/ta/580_weka_version_available_everywhere.sh
@@ -17,4 +17,8 @@ if [[ ${WEKA_CLUSTER_VERSION} != ${CURRENT_AGENT_VERSION} ]] ; then
     RETURN_CODE="254"
 fi
 
+if [[ ${RETURN_CODE} -eq 0 ]]; then
+    echo "Weka local agent matches cluster running version"
+fi
+
 exit ${RETURN_CODE}

--- a/scripts.d/ta/580_weka_version_available_everywhere.sh
+++ b/scripts.d/ta/580_weka_version_available_everywhere.sh
@@ -1,0 +1,20 @@
+#!/bin/bash                                                                                                                                                                                                                         
+
+#set -ue # Fail with an error code if there's any sub-command/variable error
+
+DESCRIPTION="Check if Weka agent version matches cluster version"
+SCRIPT_TYPE="parallel"
+JIRA_REFERENCE="WEKAPP-364875"
+WTA_REFERENCE=""
+KB_REFERENCE=""
+RETURN_CODE=0
+
+WEKA_CLUSTER_VERSION=$(weka status --json |  python3 -c 'import sys, json; data = json.load(sys.stdin) ; print(data["release"])')
+CURRENT_AGENT_VERSION=$(weka version | grep '^*' | awk '{print $2}')
+if [[ ${WEKA_CLUSTER_VERSION} != ${CURRENT_AGENT_VERSION} ]] ; then
+    echo "The currently running cluster version ${WEKA_CLUSTER_VERSION} does not match the"
+    echo " default installed local agent version ${CURRENT_AGENT_VERSION}"
+    RETURN_CODE="254"
+fi
+
+exit ${RETURN_CODE}

--- a/scripts.d/ta/590_single_dns_entry.sh
+++ b/scripts.d/ta/590_single_dns_entry.sh
@@ -1,0 +1,49 @@
+#!/bin/bash                                                                                                                                                                                                                         
+
+#set -ue # Fail with an error code if there's any sub-command/variable error
+
+DESCRIPTION="Check for at most one DNS entry for this hostname"
+SCRIPT_TYPE="parallel"
+JIRA_REFERENCE=""
+WTA_REFERENCE=""
+KB_REFERENCE=""
+RETURN_CODE=0
+
+
+DIG_EXISTS=0
+HOST_EXISTS=0
+NSLOOKUP_EXISTS=0
+NUMBER_OF_A_RECORDS=0
+HOSTNAME=$(hostname)
+
+
+if [[ $(type -P "dig") ]] ; then
+    DIG_EXISTS=1
+fi
+if [[ $(type -P "host") ]] ; then
+    HOST_EXISTS=1
+fi
+if [[ $(type -P "nslookup") ]] ; then
+    NSLOOKUP_EXISTS=1
+fi
+
+if [[ $DIG_EXISTS -eq "1" ]] ; then
+    NUMBER_OF_A_RECORDS=$(dig +short a ${HOSTNAME} | wc -l)
+elif [[ $HOST_EXISTS -eq "1" ]] ; then
+    NUMBER_OF_A_RECORDS=$(host -t a ${HOSTNAME} | wc -l)
+elif [[ $NSLOOKUP_EXISTS -eq "1" ]] ; then
+    # Last resort; rely on nslookup
+    NUMBER_OF_A_RECORDS=$(nslookup ${HOSTNAME} | grep ^Address | grep -v '#' | wc -l)
+else
+    echo "Unable to check for number of A records due to missing utilities"
+    echo "Please install one or more of dig/host/nslookup"
+    exit 254 # warn
+fi
+
+if [[ ${NUMBER_OF_A_RECORDS} != "1" ]] ; then
+    echo "There are ${NUMBER_OF_A_RECORDS} A records in DNS for ${HOSTNAME}"
+    echo "This is very likely to cause problems with (at least) SMB-W clustering"
+    RETURN_CODE="254"
+fi
+
+exit ${RETURN_CODE}


### PR DESCRIPTION
    Add a check for the number of DNS A records, which should equal 1
    
    SMB-W (at least) depends on having DNS working, and it *must* return
    exactly 1 entry. Some customer sites use e.g. dynDNS, which creates
    multiple DNS results which upsets PCS
