### PR TITLE
Add a check to verify that /opt/weka is configured to mount at boot time

### DIFF
--- a/scripts.d/ta/630_opt_weka_exists_but_not_mounted.sh
+++ b/scripts.d/ta/630_opt_weka_exists_but_not_mounted.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#set -ue # Fail with an error code if there's any sub-command/variable error
+
+DESCRIPTION="Ensure /opt/weka is mounted if it's defined and vice-versa"
+SCRIPT_TYPE="parallel"
+JIRA_REFERENCE=""
+WTA_REFERENCE=""
+KB_REFERENCE="SFDC #13589"
+RETURN_CODE=0
+
+main() {
+    if [[ ! -d /opt/weka ]] ; then
+        exit 0 # No need to check further if /opt/weka doesn't exist
+    fi
+    BOOTTIME_MOUNT_EXISTS=0
+    OPT_WEKA_MOUNTED=0
+
+    # Systemd requires that an /opt/weka mount be called opt-weka.mount
+    if systemctl list-units -t mount --all | grep -q '\<opt-weka\.mount' ; then BOOTTIME_MOUNT_EXISTS=1 ; fi
+    if grep -q '\</opt/weka\>' /etc/fstab                                ; then BOOTTIME_MOUNT_EXISTS=1 ; fi
+
+    # But is it actually mounted?
+    if awk '$2 == "/opt/weka"' /etc/mtab | grep -q weka ; then OPT_WEKA_MOUNTED=1 ; fi
+
+    if [[ ${OPT_WEKA_MOUNTED} -ne ${BOOTTIME_MOUNT_EXISTS} ]] ; then
+        echo "Either /opt/weka exists but is not defined in systemd or /etc/fstab,"
+        echo "or vice-versa."
+        echo
+        echo "This means that changes made to the live system as it is now"
+        echo "are unlikely to be present on the system post-reboot"
+        RETURN_CODE=1
+    fi
+
+    exit ${RETURN_CODE}
+}
+
+main "$@"


### PR DESCRIPTION
in SFDC 13589 we encountered a situation in which the customer had configured an extra partition for /opt/weka, and defined it in /etc/fstab but had not actually mounted it.
All changes were made to /opt/weka on the rootFS.

When the system rebooted the weka containers were missing.

This script checks for the definition of an /opt/weka mountpoint in both fstab and systemd, and whether it's currently mounted (and the inverse).

This is not foolproof because you could still achieve the same confusion by e.g. doing similar with /opt rather than /opt/weka