### PR TITLE
Add in required text output in case of successful tests

### DIFF
--- a/scripts.d/ta/590_single_dns_entry.sh
+++ b/scripts.d/ta/590_single_dns_entry.sh
@@ -43,7 +43,10 @@ fi
 if [[ ${NUMBER_OF_A_RECORDS} != "1" ]] ; then
     echo "There are ${NUMBER_OF_A_RECORDS} A records in DNS for ${HOSTNAME}"
     echo "This is very likely to cause problems with (at least) SMB-W clustering"
-    RETURN_CODE="254"
+    RETURN_CODE=254
+else
+    echo "There is exactly one A record in DNS for ${HOSTNAME}"
+    RETURN_CODE=0
 fi
 
 exit ${RETURN_CODE}

--- a/scripts.d/ta/600_fewer_than_16_numas.sh
+++ b/scripts.d/ta/600_fewer_than_16_numas.sh
@@ -14,7 +14,10 @@ NUMBER_OF_NUMA_REGIONS=$(ls -d /sys/devices/system/node/node* | wc -l)
 if [[ ${NUMBER_OF_NUMA_REGIONS} -gt 16 ]] ; then
     echo "There are ${NUMBER_OF_NUMA_REGIONS} NUMA regions"
     echo "Please see ${JIRA_REFERENCE} for more information"
-    RETURN_CODE="254"
+    RETURN_CODE=254
+else
+    echo "Fewer than 17 NUMA regions - test passed"
+    RETURN_CODE=0
 fi
 
 exit ${RETURN_CODE}

--- a/scripts.d/ta/610_nfs_aliases_sbr.sh
+++ b/scripts.d/ta/610_nfs_aliases_sbr.sh
@@ -73,6 +73,7 @@ main() {
 
    # No overlapping subnets -- exit w/ success
    else
+     echo "No overlapping subnets found"
      exit $RETURN_CODE
    fi
 }

--- a/scripts.d/ta/620_same_mtu_across_nics.sh
+++ b/scripts.d/ta/620_same_mtu_across_nics.sh
@@ -46,10 +46,15 @@ main() {
                     echo "has an MTU of ${MTU}, which is less than the MTU ${SMALLEST_MTU_REQUIRED} seen elsewhere in this host"
                     echo "This can lead to cluster communication problems"
                     echo "Please see ${JIRA_REFERENCE} for more information"
-                    RETURN_CODE="254"
+                    RETURN_CODE=254
             fi
         done
     done
+    
+    if [[ ${RETURN_CODE} -eq 0 ]] ; then
+        echo "No mismatched large/small MTUs found"
+    fi
+    
     exit $RETURN_CODE
 }
 

--- a/scripts.d/ta/630_opt_weka_exists_but_not_mounted.sh
+++ b/scripts.d/ta/630_opt_weka_exists_but_not_mounted.sh
@@ -29,7 +29,9 @@ main() {
         echo
         echo "This means that changes made to the live system as it is now"
         echo "are unlikely to be present on the system post-reboot"
-        RETURN_CODE=1
+        RETURN_CODE=254
+    else
+        echo "No immediate directory/mount overlaps found"
     fi
 
     exit ${RETURN_CODE}


### PR DESCRIPTION
Each of these tests needs to return some text even in the case of success.

Get rid of pointless quotes around lvalue.