### PR TITLE
NetworkManager ignore-carrier check

### DIFF
--- a/scripts.d/ta/670_nm_ignore_carrier.sh
+++ b/scripts.d/ta/670_nm_ignore_carrier.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#set -ue # Fail with an error code if there's any sub-command/variable error
+
+DESCRIPTION="Check to see if NetworkManager has ignore-carrier"
+SCRIPT_TYPE="parallel"
+JIRA_REFERENCE=""
+WTA_REFERENCE=""
+KB_REFERENCE=""
+RETURN_CODE=0
+
+if nmcli -v &> /dev/null; then
+  if nmcli dev status | grep connected &> /dev/null; then
+    IGNORE_CARRIER=$(NetworkManager --print-config | grep -E -v ^# | grep ignore-carrier | cut -d '=' -f 2)
+    if [[ -z $IGNORE_CARRIER ]]; then
+      RETURN_CODE=254
+      echo "NetworkManager ignore-carrier is not set. Recommended value is ignore-carrier=*"
+    elif [[ "$IGNORE_CARRIER" != "*" ]]; then
+      RETURN_CODE=254
+      echo "NetworkManager ignore-carrier is set to ${IGNORE_CARRIER}, but recommended value is ignore-carrier=*"
+    else
+      echo "NetworkManager ignore-carrier=* exists."
+    fi
+  else
+    echo "NetworkManager not in use."
+  fi
+else
+  echo "NetworkManager not in use."
+fi
+
+exit ${RETURN_CODE}


### PR DESCRIPTION
Check to see if NetworkManager is managing interfaces, and if so, check to see if the global ignore-carrier parameter is set to *.