### PR TITLE
Simplify the test for Hyperthreading / SMT

### DIFF
--- a/scripts.d/default/150_htcputest.sh
+++ b/scripts.d/default/150_htcputest.sh
@@ -1,28 +1,22 @@
 #!/bin/bash
 
-DESCRIPTION="Check if HT/AMT is disabled"
+DESCRIPTION="Check if Hyperthreading (SMT) is disabled"
 SCRIPT_TYPE="parallel"
 
-# Checking if CPU has HyperThreading available and running or disabled
-which dmidecode &> /dev/null
-if [ $? -eq 1 ]; then
-	echo "Dmidecode tool wasn't found, could not test HyperThreading properly"
-	ret="0"
-else
-	nproc=$(grep -i "processor" /proc/cpuinfo | sort -u | wc -l)
-	phycore=$(cat /proc/cpuinfo | egrep "core id|physical id" | tr -d "\n" | sed s/physical/\\nphysical/g | grep -v ^$ | sort | uniq | wc -l)
-	if [ -z "$(echo $(($phycore*2)) | grep $nproc)" ]; then
-		echo "Does not look like you have HTi/AMT Enabled"
-		if [ -z "$( dmidecode -t processor | grep HTT)" ]; then
-			echo "HyperThreading/AMT isn't available on this machine"
-			ret="0"
-		else
-			echo "This server is HyperThreading capable, however, it is disabled"
-			ret="0"
-		fi
-	else
-		echo "HyperThreading/AMT is enabled; disabled is recommended"
-		ret="254"
-	fi
+RETURN_CODE=0
+SMT_FILE="/sys/devices/system/cpu/smt/active"
+if [[ ! -e "${SMT_FILE}" ]] ; then
+    echo "File ${SMT_FILE} does not exist, assuming no hyperthreading"
+    RETURN_CODE=0
+    exit ${RETURN_CODE}
 fi
-exit $ret
+    
+SMT_ACTIVE=$(cat "${SMT_FILE}")
+if [[ ${SMT_ACTIVE} -eq "0" ]] ; then
+    echo "Hyperthreading/SMT is inactive, passing test"
+    RETURN_CODE=0
+else
+    echo "Hyperthreading/SMT is active, which is not recommended"
+    RETURN_CODE=254
+fi
+exit ${RETURN_CODE}

--- a/scripts.d/ta/150_htcputest.sh
+++ b/scripts.d/ta/150_htcputest.sh
@@ -1,29 +1,22 @@
 #!/bin/bash
 
-DESCRIPTION="Check if HT/AMT is disabled"
+DESCRIPTION="Check if Hyperthreading (SMT) is disabled"
 SCRIPT_TYPE="parallel"
 
-ret="0"
-# Checking if CPU has HyperThreading available and running or disabled
-which dmidecode &> /dev/null
-if [ $? -eq 1 ]; then
-	echo "Dmidecode tool wasn't found, could not test HyperThreading properly"
-	ret="0"
-else
-	nproc=$(grep -i "processor" /proc/cpuinfo | sort -u | wc -l)
-	phycore=$(cat /proc/cpuinfo | egrep "core id|physical id" | tr -d "\n" | sed s/physical/\\nphysical/g | grep -v ^$ | sort | uniq | wc -l)
-	if [ -z "$(echo $(($phycore*2)) | grep $nproc)" ]; then
-		echo "Does not look like you have HTi/AMT Enabled"
-		if [ -z "$( dmidecode -t processor | grep HTT)" ]; then
-			echo "HyperThreading/AMT isn't available on this machine"
-			ret="0"
-		else
-			echo "This server is HyperThreading capable, however, it is disabled"
-			ret="0"
-		fi
-	else
-		echo "HyperThreading/AMT is enabled; disabled is recommended"
-		ret="254"
-	fi
+RETURN_CODE=0
+SMT_FILE="/sys/devices/system/cpu/smt/active"
+if [[ ! -e "${SMT_FILE}" ]] ; then
+    echo "File ${SMT_FILE} does not exist, assuming no hyperthreading"
+    RETURN_CODE=0
+    exit ${RETURN_CODE}
 fi
-exit $ret
+    
+SMT_ACTIVE=$(cat "${SMT_FILE}")
+if [[ ${SMT_ACTIVE} -eq "0" ]] ; then
+    echo "Hyperthreading/SMT is inactive, passing test"
+    RETURN_CODE=0
+else
+    echo "Hyperthreading/SMT is active, which is not recommended"
+    RETURN_CODE=254
+fi
+exit ${RETURN_CODE}


### PR DESCRIPTION
Issue reported via Slack about parsing the output of cpuinfo, so... Rather than relying on the existence and output of dmidecode and /proc/cpuinfo, it actually makes more sense to read /sys/devices/system/cpu/smt/active, which is old, simple, and widely available.
I think it exists everywhere on kernel >2.6.

Fixed (assumed) typo about AMT -> SMT.