### PR TITLE
Limit warning to only those cases where the routing destinations match

### DIFF
--- a/scripts.d/ta/490_ip_route_metrics.sh
+++ b/scripts.d/ta/490_ip_route_metrics.sh
@@ -2,7 +2,7 @@
 
 #set -ue # Fail with an error code if there's any sub-command/variable error
 
-DESCRIPTION="Check if IP routing uses metrics"
+DESCRIPTION="Check if IP routing uses metrics with the same destination"
 SCRIPT_TYPE="parallel"
 JIRA_REFERENCE=""
 WTA_REFERENCE=""
@@ -20,15 +20,28 @@ if [[ $status -ne 0 ]]; then
     exit 254 # WARN
 fi
 
-NUMBER_OF_ROUTES_WITH_METRICS=$(ip -4 --json route | python3 -c '
+# First find any routes that specify a route metric, then count them based
+# on the same routing destination. A single route to a destination with
+# a metric is fine (because the metric is meaningless there), but routes
+# which specify the same destination *and* a metric is not likely to be useful.
+#  (There are circumstances where it makes sense, such as a backup/failover
+#   route that's not intended to be preferred)
+NUMBER_OF_OVERLAPPING_ROUTES_WITH_METRICS=$(ip -4 --json route | python3 -c '
 import sys, json
 data = json.load(sys.stdin)
-print(len([r for r in data if r.get("metric") and r["metric"]]))
+
+overlappingRoutesWithMetric = {}
+
+for r in data:
+    if r.get("metric") and r["metric"]:
+        overlappingRoutesWithMetric[r["dst"]] = overlappingRoutesWithMetric.get(r["dst"], 0) + 1
+
+print(max(overlappingRoutesWithMetric.values()))
 ')
 
-if [[ ${NUMBER_OF_ROUTES_WITH_METRICS} -gt "0" ]]; then
+if [[ ${NUMBER_OF_OVERLAPPING_ROUTES_WITH_METRICS} -gt "1" ]]; then
     RETURN_CODE="254"
-    echo "Detected routing entries which specify a metric. It is possible"
+    echo "Detected more than 1 overlapping routing entries which specify a metric. It is possible"
     echo "that these entries will negatively affect the performance of e.g. floating IP"
     echo "addresses. In any case it is unlikely that preferential IP routes are of"
     echo "benefit in a high-performance local network"

--- a/scripts.d/ta/490_ip_route_metrics.sh
+++ b/scripts.d/ta/490_ip_route_metrics.sh
@@ -36,7 +36,8 @@ for r in data:
     if r.get("metric") and r["metric"]:
         overlappingRoutesWithMetric[r["dst"]] = overlappingRoutesWithMetric.get(r["dst"], 0) + 1
 
-print(max(overlappingRoutesWithMetric.values()))
+if overlappingRoutesWithMetric:
+    print(max(overlappingRoutesWithMetric.values()))
 ')
 
 if [[ ${NUMBER_OF_OVERLAPPING_ROUTES_WITH_METRICS} -gt "1" ]]; then


### PR DESCRIPTION
The previous version warned simply if we had metrics set, but that's not precise enough; metrics only really matter if the routes have the same destination. Even then there has to be more than one metric-having route to the same destination for us to actually have a problem, therefore:

First find any routes that specify a route metric, then count them based on the same routing destination. A single route to a destination with a metric is fine (because the metric is meaningless there), but routes which specify the same destination *and* a metric is not likely to be useful. (There are circumstances where it makes sense, such as a backup/failover
 route that's not intended to be preferred)