### PR TITLE
Increase number of supported NUMA domains from 20 to 32

### DIFF
--- a/scripts.d/ta/470_number_of_numa_domains.sh
+++ b/scripts.d/ta/470_number_of_numa_domains.sh
@@ -10,7 +10,7 @@ KB_REFERENCE=""
 RETURN_CODE=0
 
 main () {
-    MAXIMUM_NUMA_DOMAINS="20" # as of 4.2.11
+    MAXIMUM_NUMA_DOMAINS="32" # as of 4.2.11 (WEKAPP-381838)
 
     # Check if we can run weka commands
     weka status &> /dev/null
@@ -29,21 +29,26 @@ main () {
     NUMBER_OF_NUMA_DOMAINS=$(ls -d /sys/devices/system/node/node* |wc -l)
     echo "Detected $NUMBER_OF_NUMA_DOMAINS NUMA domains."
 
-    # More than 20 NUMAs is unsupported
+    # More than 32 NUMAs is unsupported
     if [[ $NUMBER_OF_NUMA_DOMAINS -gt $MAXIMUM_NUMA_DOMAINS ]]; then
         RETURN_CODE=254
-        echo "Weka currenty only supports a maximum of 20 NUMA domains (4.2.11+)."
+        echo "Weka currenty only supports a maximum of 32 NUMA domains (4.2.11+)."
 
     # 8 or fewer NUMAs is always supported
     elif [[ $NUMBER_OF_NUMA_DOMAINS -le 8 ]]; then
         echo "Number of NUMA domains is within supported limits."
 
-    # 16 or higher NUMAs only supported in 4.2.11+
+    # More than 16 NUMAs only supported in 4.3.2+
+    elif vergte $WEKA_VERSION "4.3.0" && verlt $WEKA_VERSION "4.3.2" && [[ $NUMBER_OF_NUMA_DOMAINS -gt 16 ]]; then
+        RETURN_CODE=254
+        echo "Weka only supports more than 16 NUMA domains in 4.3.2 and higher."
+
+    # More than 16 NUMAs only supported in 4.2.11+
     elif vergt $WEKA_VERSION "4.2.6" && verlt $WEKA_VERSION "4.2.11" && [[ $NUMBER_OF_NUMA_DOMAINS -gt 16 ]]; then
         RETURN_CODE=254
-        echo "Weka only supports more than 16 NUMA domains in 4.2.11 and higher."
+        echo "Weka only supports more than 16 NUMA domains in (4.2.11+, 4.3.2+)."
 
-    # 8 or higher NUMAs only supported in 4.2.7+
+    # More than 8 NUMAs only supported in 4.2.7+
     elif verlt $WEKA_VERSION "4.2.7" && [[ $NUMBER_OF_NUMA_DOMAINS -gt 8 ]]; then
         RETURN_CODE=254
         echo "Weka only supports more than 8 NUMA domains in 4.2.7 and higher."
@@ -56,9 +61,13 @@ main () {
 }
 
 # Derived from https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
+vergte() {
+    [  "$1" = "$(echo -e "$1\n$1" | sort -V | tail -n1)" ]
+}
+
 verlte() {
     [  "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
-}       
+}
 
 verlt() {
     [ "$1" = "$2" ] && return 1 || verlte $1 $2


### PR DESCRIPTION
The maximum number of NUMA domains, in 4.2.11+ and 4.3.2+, is 32, not 20. This change corrects this.