### PR TITLE
Check NVME LBA update

### DIFF
--- a/scripts.d/ta/223_checknvmelba.sh
+++ b/scripts.d/ta/223_checknvmelba.sh
@@ -44,7 +44,7 @@ rc=0
 # Exit with warning if no NVMes are found
 if ! compgen -G /dev/nvme*n* 2> /dev/null; then
 	echo 'No NVMe devices found'
-	exit 254
+	exit 0
 fi
 
 # Populate arrays


### PR DESCRIPTION
Do not return a warning if an NVMe does not exist.