### PR TITLE
Bugfix: Previously relied on exit status of awk, which was a constant

### DIFF
--- a/scripts.d/ta/740_mlx_settings.sh
+++ b/scripts.d/ta/740_mlx_settings.sh
@@ -49,11 +49,11 @@ if [[ ${#PCI_BUSES[@]} -gt 0 ]]; then
     for PCI in "${!PCI_BUSES[@]}"; do
         if [[ -n ${PCI_BUSES[$PCI]} ]]; then
             while read DEV; do
-                if mlxconfig -d "$DEV" q | awk '/PCI_WR_ORDERING/ && /(0)/' &> /dev/null; then
+                if mlxconfig -d "$DEV" q |  grep -q 'PCI_WR_ORDERING.*(0)'; then
                     RETURN_CODE=254
                     echo "PCI_WR_ORDERING set to 0 on ${PCI_BUSES[$PCI]} - recommended value is 1."
                 fi
-                if mlxconfig -d "$DEV" q | awk '/ADVANCED_PCI_SETTINGS/ && /(0)/' &> /dev/null; then
+                if mlxconfig -d "$DEV" q | grep -q 'ADVANCED_PCI_SETTINGS.*(0)'; then
                     RETURN_CODE=254
                     echo "ADVANCED_PCI_SETTINGS set to 0 on ${PCI_BUSES[$PCI]} - recommended value is 1."
                 fi


### PR DESCRIPTION
Previously:
[root ]# mlxconfig -d /dev/mst/mt4123_pciconf1 q | awk '/PCI_WR_ORDERING/ && /(0)/' [root ]# echo $?
0
[root ]# mlxconfig -d /dev/mst/mt4123_pciconf1 q | awk '/PCI_WR_ORDERING/ && /(1)/'
         PCI_WR_ORDERING                             force_relax(1)
[root ]# echo $?
0

therefore simplify a little to grep.