### PR TITLE
Allow IB NIC Name matching to handle PKEY device names

### DIFF
--- a/scripts.d/ta/865_infiniband_lid_mismatch.sh
+++ b/scripts.d/ta/865_infiniband_lid_mismatch.sh
@@ -25,7 +25,7 @@ declare -A NIC_LIDS
 # Is the cluster using a NIC over Infiniband?
 while read CONTAINER; do
     while read NET_ENTRY; do
-        if [[ ${NET_ENTRY} =~ "name:"(.*) ]]; then
+        if [[ ${NET_ENTRY} =~ "name:"([^.]*) ]]; then
             NET_NAME=${BASH_REMATCH[1]}
             if [[ $(cat /sys/class/net/${NET_NAME}/type) == 32 ]]; then
                 IB_INTERFACE=${NET_NAME}


### PR DESCRIPTION
If the cluster is using PKEYs on Infiniband, then NIC names change from e.g. "ib3" to "ib3.8001". However, the LID information still exists under the base device name in sysfs, e.g.:

/sys/class/net/ibs3/device/infiniband/mlx5_0/ports/1/lid

This change allows the regex to match any character except dot, which seems a logical way of handling it.