### PR TITLE
Allow the lookup table to be anywhere in the output of 'ip rule'

### DIFF
--- a/scripts.d/ta/460_ip_source-based_routing.sh
+++ b/scripts.d/ta/460_ip_source-based_routing.sh
@@ -202,7 +202,7 @@ for PREFIX in ${!WEKA_INTERFACES_OVERLAP[@]}; do
                 RETURN_CODE=254
                 echo "WARNING: No ip rule found for IP ${netinfo[0]}".
             else
-                ROUTE_TABLE=$(ip rule | grep -m 1 -F "${netinfo[0]}" | awk '{print $NF}')
+                ROUTE_TABLE=$(ip rule | grep -m 1 -F "${netinfo[0]}" | sed -r 's/.*lookup *(\w+).*/\1/')
                 if ! ip route show table ${ROUTE_TABLE} &> /dev/null; then
                     RETURN_CODE=254
                     echo "WARNING: route table ${ROUTE_TABLE} not found."


### PR DESCRIPTION
Previously we assumed that 'ip rule' would output with the table name at the very end of the line. Depending on how that rule is added it might not be; it could be e.g.

32764:  from 10.31.62.119 lookup 100 proto static

Therefore instead capture "the word after 'lookup'" instead.