### PR TITLE
Move from arp_ignore=0 to arp_ignore=1

### DIFF
--- a/scripts.d/ta/460_ip_source-based_routing.sh
+++ b/scripts.d/ta/460_ip_source-based_routing.sh
@@ -39,7 +39,7 @@ declare -A WEKA_INTERFACES_OVERLAP
 #
 #       arp_filter for the interface will be enabled if at least one of conf/{all,interface}/arp_filter is set to TRUE, it will be disabled otherwise
 
-# arp_ignore -- Weka recommends a value of 0
+# arp_ignore -- Weka recommends a value of 1
 #  Ref: https://sysctl-explorer.net/net/ipv4/arp_ignore/
 #   Define different modes for sending replies in response to received ARP requests that resolve local target IP addresses: 
 #   0 - (default): reply for any local target IP address, configured on any interface 
@@ -180,15 +180,15 @@ for PREFIX in ${!WEKA_INTERFACES_OVERLAP[@]}; do
                fi
             fi
     
-            # Validate arp_ignore (should be 0)
-            if [[ $(sysctl -n net.ipv4.conf.${NIC}.arp_ignore) != "0" ]]; then
+            # Validate arp_ignore (should be 1)
+            if [[ $(sysctl -n net.ipv4.conf.${NIC}.arp_ignore) != "1" ]]; then
                 RETURN_CODE=254
-                echo "WARNING: arp_ignore is not set to 0 on interface ${NIC}".
+                echo "WARNING: arp_ignore is not set to 1 on interface ${NIC}".
             fi
         
-            if [[ $(sysctl -n net.ipv4.conf.all.arp_ignore) != "0" ]]; then
+            if [[ $(sysctl -n net.ipv4.conf.all.arp_ignore) != "1" ]]; then
                 RETURN_CODE=254
-                echo "WARNING: arp_ignore is not set to 0 on net.ipv4.conf.all.arp_ignore."
+                echo "WARNING: arp_ignore is not set to 1 on net.ipv4.conf.all.arp_ignore."
                 echo "This value may override the arp_ignore value on specific network interfaces."
             fi
         


### PR DESCRIPTION
In August 2025 we saw that -- for reasons unknown -- docs (and thus TA Tool) recommended arp_ignore=0. This is unwise as it allows the Linux kernel to respond to ARP requests for NIC A via NIC B, which has a habit of getting switches to learn the wrong MAC Address for their CAM tables.

https://wekaio.slack.com/archives/C05QSG8HCF9/p1755274686557269 https://wekaio.slack.com/archives/C03E96QFM33/p1755509369672719